### PR TITLE
impl: edit ministop crawler

### DIFF
--- a/crawlers/ministop.py
+++ b/crawlers/ministop.py
@@ -35,21 +35,41 @@ def crawl_ministop():
     driver.execute_script("arguments[0].click();", btn)
 
 
-    '''3. 각 점포 정보 저장하기''' 
+    '''4. 각 점포 정보 저장하기''' 
     for i in range(1, 261):
         li_element = driver.find_element(By.XPATH, f'//*[@id="section"]/div[3]/div/div[2]/div[2]/div[1]/ul/li[{i}]')
         li_lines = li_element.text.split('\n')
         name = li_lines[0]
         address = li_lines[1]
-                            
+
+        print(address)
+        
+        lat = ''
+        lon = ''
+        latlon_address = addr_to_lat_lon(address)
+        if latlon_address is not None:
+            try:
+                lon = latlon_address[0]
+                lat = latlon_address[1]
+            except IndexError as e:
+                print(f"Error occurred while extracting latitude and longitude from address {address}: {e}")
+                pass
                     
+        print(lat, lon)
+        
         jumpos_info.append({
             'jumpo_name': name, 
             'street_address' : address, 
-            'latitude': 37.564214,
-            'longitude': 127.001699,}
+            'latitude': lat, # 위도 
+            'longitude': lon, } # 경도
             )
         
     return jumpos_info
 
 
+
+def main():
+    Save_data(Crawling())
+
+if __name__ == "__main__":
+    main()

--- a/crawlers/ministop.py
+++ b/crawlers/ministop.py
@@ -45,23 +45,23 @@ def crawl_ministop():
         print(address)
         
         lat = ''
-        lon = ''
-        latlon_address = addr_to_lat_lon(address)
-        if latlon_address is not None:
+        lng = ''
+        latlng_address = addr_to_lat_lng(address)
+        if latlng_address is not None:
             try:
-                lon = latlon_address[0]
-                lat = latlon_address[1]
+                lng = latlng_address[0]
+                lat = latlng_address[1]
             except IndexError as e:
                 print(f"Error occurred while extracting latitude and longitude from address {address}: {e}")
                 pass
                     
-        print(lat, lon)
+        print(lat, lng)
         
         jumpos_info.append({
             'jumpo_name': name, 
             'street_address' : address, 
             'latitude': lat, # 위도 
-            'longitude': lon, } # 경도
+            'longitude': lng, } # 경도
             )
         
     return jumpos_info


### PR DESCRIPTION
⭐️ 요청 사항
각자 크롤러 함수에서 다음과 같은 코드를 추가해 주시면 감사하겠습니다.

```python
# 위도 경도 가져오는 부분 
        lat = ''
        lon = ''
        latlon_address = addr_to_lat_lon(address)
        if latlon_address is not None:
            try:
                lon = latlon_address[0]
                lat = latlon_address[1]
            except IndexError as e:
                print(f"Error occurred while extracting latitude and longitude from address {address}: {e}")
                pass
```
                
⭐️ 추가 이유 
1. kakao api를 이용해 주소를 위도경도로 바꾸는 함수를 개발
2. 크롤해온 데이터에 적용하는 과정에서 주소변환이 안되는 케이스 발견
3. 이를 위한 에러처리를 위해 각 크롤러.py에서 추가 작업 필요