### PR TITLE
improve: move token config into settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@
 
 6. 발급받은 API 키를 환경변수로 저장합니다.
    ```sh
-   export KAKAO_TOKEN="발급받은 키"
+   export KAKAO_REST_KEY="발급받은 키"
+   export KAKAO_JS_KEY="발급받은 키"
    ```
 7. django mangement 명령어를 통해 편의점 데이터를 다운받습니다. 
    ```sh

--- a/seulsegown/settings.py
+++ b/seulsegown/settings.py
@@ -11,10 +11,14 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Kakao API keys
+KAKAO_REST_KEY = os.getenv('KAKAO_REST_KEY')
+KAKAO_JS_KEY = os.getenv('KAKAO_JS_KEY')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/

--- a/store/management/commands/crawl.py
+++ b/store/management/commands/crawl.py
@@ -50,6 +50,7 @@ class Command(BaseCommand):
         parser.add_argument('--brand', type=str, help='specify a brand to crawl')
         parser.add_argument('--all', action='store_true', help='crawl all brands')
 
+    # pylint: disable=W0613
     def handle(self, *args, **options):
         '''
         manage.py로 명령어를 실행할 시에 호출되는 콜백 함수입니다.

--- a/store/templates/store/result.html
+++ b/store/templates/store/result.html
@@ -34,7 +34,7 @@
         <button id = "how_to_score_btn" type="button" class="btn btn-outline-primary">슬세권 점수 산정기준을 보고싶다면?</button>
         <button id = "visualization_btn" type="button" class="btn btn-outline-primary">서울 편의점 분포를 한눈에 보고싶다면?</button>
       </div>
-      <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=a1a7158a6d3c833a4a06b2d950389f81&libraries=services"></script>
+      <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey={{ KAKAO_JS_KEY }}&libraries=services"></script>
       <script src="{% static 'js/script.js' %}"></script>
       <script>
         $( document ).ready(function() {

--- a/store/tests.py
+++ b/store/tests.py
@@ -1,3 +1,4 @@
+# pylint: disable=C0114, W0611
 from django.test import TestCase
 
 # Create your tests here.

--- a/store/views.py
+++ b/store/views.py
@@ -1,5 +1,6 @@
 """store view module"""
 from django.shortcuts import render
+from django.conf import settings
 from store.models import Jumpo
 from utils.utils import addr_to_lat_lng, calculate_seulsegown_score
 import math
@@ -59,11 +60,12 @@ def result(request):
         # position: 위도, 경도 쌍
         # jumpos: 사용자 근처의 점포 목록
         return render(request, 'store/result.html', {
-                'address': address,
-                'position': [lat, lng],
-                'jumpos': json.dumps(sorted(jumpos, key=lambda x: x['distance']), ensure_ascii=False),
-                'score': calculate_seulsegown_score(jumpos),
-                })
+            'address': address,
+            'position': [lat, lng],
+            'jumpos': json.dumps(sorted(jumpos, key=lambda x: x['distance']), ensure_ascii=False),
+            'score': calculate_seulsegown_score(jumpos),
+            'KAKAO_JS_KEY': settings.KAKAO_JS_KEY,
+        })
     # 서울이 아닌경우
     else:
         # 입력이 빈칸인 경우

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -1,10 +1,8 @@
+'''tests for utils'''
 from django.test import TestCase
 from unittest.mock import patch
 from utils.utils import get_latlng_range, get_distance, addr_to_lat_lng, calculate_seulsegown_score
 import json
-import math
-import requests
-
 
 class CalculateScoreTest(TestCase):
     def test_calculate_score(self):
@@ -68,6 +66,7 @@ class GetDistanceTest(TestCase):
         self.assertAlmostEqual(result_distance, expected_distance, places=2)
 
 
+# pylint: disable=C0115
 class AddrToLatLngTestCase(TestCase):
     def setUp(self):
         self.mock_result = {

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -6,10 +6,10 @@ This module provide functions to calculate distance, get latlng range, etc.
 import math
 import requests
 import json
-import os
+from django.conf import settings
 
 # 터미널에서 export로 키를 저장하시면 됩니다.
-token = os.getenv('KAKAO_TOKEN')
+token = settings.KAKAO_REST_KEY
 
 EARTH_RADIUS = 6371  # 지구 반지름(km)
 


### PR DESCRIPTION
여기 저기 흩어져있던 ENV에서 kakao api key를 불러오는 과정을 settings.py로 옮겼습니다.
하드코딩된 JS KEY도 환경변수로 변경하였습니다.

```sh
export KAKAO_REST_KEY="발급받은 키"
export KAKAO_JS_KEY="발급받은 키"
```
