### PR TITLE
fix: run pylint on push

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,7 +2,7 @@ name: Pylint
 
 on:
   pull_request:
-    types: [opened]
+  push:
 
 jobs:
   build:


### PR DESCRIPTION
pylint가 pull_request 열렸을 때 뿐 아니라 push 할 때에도 돌도록 바꿉니다.